### PR TITLE
[SERF-841] Bump terraform version to 0.13.7 in the Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,8 @@
 pipeline {
     agent {
         kubernetes {
-            label 'terraform-0-12-20'
-            defaultContainer 'terraform-0-12-20'
+            label 'terraform-0-13-7'
+            defaultContainer 'terraform-0-13-7'
         }
     }
 


### PR DESCRIPTION
## Description

Currently, Terraform 0.13 is our primary version for the modules maintained by the Service Foundations and Core Services teams.  The PR bumps terraform version to `0.13.7` in the Jenkins pipeline.

## Related

* https://scribdjira.atlassian.net/browse/SERF-841