### PR TITLE
[SERF-1384] Add support for cross-account access to secrets

### DIFF
--- a/kms.tf
+++ b/kms.tf
@@ -1,0 +1,43 @@
+data "aws_iam_policy_document" "master" {
+  count = length(local.arns) > 0 ? 1 : 0
+
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = [data.aws_caller_identity.current.account_id]
+    }
+
+    actions   = ["kms:*"]
+    resources = ["*"]
+  }
+
+  statement {
+    principals {
+      type        = "AWS"
+      identifiers = flatten(values(local.arns))
+    }
+
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_kms_key" "master" {
+  count = length(local.arns) > 0 ? 1 : 0
+
+  description = "The master key for ${var.app_name} application"
+  policy      = data.aws_iam_policy_document.master[0].json
+
+  tags = var.tags
+}
+
+resource "aws_kms_alias" "master" {
+  count = length(local.arns) > 0 ? 1 : 0
+
+  name = "alias/${var.app_name}"
+
+  target_key_id = aws_kms_key.master[0].key_id
+}

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,8 @@ resource "aws_secretsmanager_secret" "app" {
   name_prefix = "${var.app_name}-${each.key}"
   description = "The ${title(replace(each.key, "-", " "))} secret for ${var.app_name} application"
 
+  kms_key_id = length(local.arns) > 0 ? aws_kms_key.master[0].key_id : null
+
   policy = lookup(local.arns, each.key, null) == null ? null : data.aws_iam_policy_document.access[each.key].json
 
   tags = merge(var.tags, { "service" = var.app_name })

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,13 @@ output "all" {
     }
   ]
 }
+
+output "kms_key_arn" {
+  description = "The master key ARN"
+  value       = length(local.arns) > 0 ? aws_kms_key.master[0].arn : null
+}
+
+output "kms_alias_arn" {
+  description = "The master key alias ARN"
+  value       = length(local.arns) > 0 ? aws_kms_alias.master[0].arn : null
+}


### PR DESCRIPTION
## Description

The PR adds support for cross-account access to secrets.

## Testing considerations

The changes are backward-compatible. The PR was tested in development and staging environments:
* For the single-account secrets, no terraform changes.
* For the cross-account secrets I've verified the steps [described in the README](https://github.com/scribd/terraform-aws-app-secrets/blob/da8860383712ddcd5fb9fa33139af1f626493f45/README.md#example-usage) and they work as advertised.

## Checklist

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [x] Updated the `README.md` as necessary

## Related links

* [SERF-1384](https://scribdjira.atlassian.net/browse/SERF-1384)

[commit messages]: https://chris.beams.io/posts/git-commit/
