### PR TITLE
[TOOLS-4230] Add CODEOWNERS validation to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,12 @@ jobs:
         env:
           AWS_DEFAULT_REGION: "us-east-2"
           TF_IN_AUTOMATION: "true"
+
+  codeowners:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: GitHub CODEOWNERS Validator
+        uses: mszostok/codeowners-validator@v0.7.1
+        with:
+          checks: "files,duppatterns,syntax"


### PR DESCRIPTION
## Description

This is part of the ITGC initiative ensuring all business-critical repos are compliant. The codeowners-validator must be present to ensure the integrity of the code review process. However, we cannot use scribd's internal shared-workflow since this is a public repository. Therefore, we just call the underlying codeowner validator directly.

## Testing considerations

Confirmed the [check is passing in CI](https://github.com/scribd/terraform-aws-app-secrets/runs/5222525354?check_suite_focus=true).

## Related links

* [TOOLS-4230](https://scribdjira.atlassian.net/browse/TOOLS-4230)

[commit messages]: https://chris.beams.io/posts/git-commit/