### PR TITLE
[SERF-1846] Mark secrets as sensitive by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ module "user" {
 
 | Name            | Description                              | Sensitive |
 | --------------- | ---------------------------------------- | --------- |
-| `all`           | Map of names and arns of created secrets | no        |
+| `all`           | Map of names and arns of created secrets | yes       |
 | `kms_key_arn`   | The master key ARN                       | no        |
 | `kms_alias_arn` | The master key alias ARN                 | no        |
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,8 @@ output "all" {
       arn  = aws_secretsmanager_secret.app[name].id
     }
   ]
+
+  sensitive = true
 }
 
 output "kms_key_arn" {


### PR DESCRIPTION
## Description

Terraform 0.14 [is more strict](https://www.terraform.io/language/upgrade-guides/0-14#sensitive-values-in-plan-output) when it comes to sensitivity-awareness of the input and output variables passed to/from the modules.

The PR marks the secret outputs as sensitive by default. These outputs are already marked as sensitive in many of our modules and cause Terraform 0.14 plans fail with the following error if the secrets are not marked as sensitive across all the module stack:

```
Error: Output refers to sensitive values

  on .terraform/modules/app.secrets/outputs.tf line 1:
   1: output "all" {

Expressions used in outputs can only refer to sensitive values if the sensitive attribute is true.
```

## Testing considerations

The change has been tested in the internal Terraform 0.14 CI/CD pipelines.

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [x] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-1846](https://scribdjira.atlassian.net/browse/SERF-1846)

[commit messages]: https://chris.beams.io/posts/git-commit/
