### PR TITLE
[SERF-2381] Bump Ubuntu to v22.04 in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   validate:
     name: validate
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         activity: ["0.13.7", "0.14.11", "1.0.11"]
@@ -32,7 +32,7 @@ jobs:
           TF_IN_AUTOMATION: "true"
 
   codeowners:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: GitHub CODEOWNERS Validator

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on: workflow_dispatch
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
## Description

Upgrade GitHub Actions to Ubuntu 22.04 (LTS). It's a maintenance PR so no release will be cut.

## Testing considerations

The CI/CD pipeline works for [validation](https://github.com/scribd/terraform-aws-app-secrets/actions/runs/4405872296).

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] ~Updated the `README.md` as necessary~

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-2381](https://scribdjira.atlassian.net/browse/SERF-2381)

[commit messages]: https://chris.beams.io/posts/git-commit/


[SERF-2381]: https://scribdjira.atlassian.net/browse/SERF-2381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ