### PR TITLE
Bump semantic-release to v19.0.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v2
         with:
-          semantic_version: 17.4.4
+          semantic_version: 19.0.5
           extra_plugins: |
-            @semantic-release/changelog@5.0.1
-            @semantic-release/exec@5.0.0
-            @semantic-release/git@9.0.0
-            @semantic-release/github@7.2.3
+            @semantic-release/changelog@6.0.2
+            @semantic-release/exec@6.0.3
+            @semantic-release/git@10.0.1
+            @semantic-release/github@8.0.7
         env:
           GITHUB_TOKEN: ${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }}


### PR DESCRIPTION
## Description

It's a follow-up to https://github.com/scribd/terraform-aws-app-secrets/pull/16. It's a maintenance PR to bump semantic-release to `v19.0.5`. No new releases will be cut.

## Testing considerations

The update has been tested in the [pipeline](https://github.com/scribd/terraform-aws-app-secrets/actions/runs/4406097128/jobs/7717864328). A new temp version `v2.3.2` has been released successfully:
```
Published release 2.3.2 on vadimka/bump-semantic-release channel
```

![Screenshot 2023-03-13 at 15 35 40](https://user-images.githubusercontent.com/4525708/224733509-d3334bb7-7ebb-4f25-be3b-7eabbdf6a3f3.png)

The temp release has been deleted.

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [ ] ~Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->~
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] ~Updated the `README.md` as necessary~

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* https://github.com/scribd/terraform-aws-app-secrets/pull/16

[commit messages]: https://chris.beams.io/posts/git-commit/
