### PR TITLE
[SERF-3091] Drop Terraform support lower than 1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup terraform ${{ matrix.activity }}
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: ${{ matrix.activity }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        activity: ["0.13.7", "0.14.11", "1.0.11"]
+        activity: ["1.0.11", "1.1.9", "1.2.9", "1.3.10", "1.4.7", "1.5.7"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A module to create application secrets stored in [AWS Secrets Manager](https://a
 
 ## Prerequisites
 
-* [Terraform](https://www.terraform.io/downloads.html) (version `0.13.7` or higher)
+* [Terraform](https://www.terraform.io/downloads.html) (version `1.0.0` or higher)
 * [AWS provider](https://www.terraform.io/docs/providers/aws/) (version `2.60` or higher)
 
 ## Example usage
@@ -210,17 +210,17 @@ module "user" {
 
 ## Inputs
 
-| Name         | Description                            | Type         | Default     | Required  |
-| ------------ | -------------------------------------- | ------------ | ----------- | --------- |
-| `app_name`   | Application name                       | string       | `null`      | yes       |
-| `aws_region` | AWS region                             | string       | `us-east-2` | no        |
-| `secrets`    | List of objects of [secrets](#secrets) | list(object) | `null`      | yes       |
-| `tags`       | Key-value map of tags                  | map(string)  | `{}`        | no        |
+| Name         | Description                            | Type         | Default     | Required |
+|:-------------|:---------------------------------------|:-------------|:------------|:---------|
+| `app_name`   | Application name                       | string       | `null`      | yes      |
+| `aws_region` | AWS region                             | string       | `us-east-2` | no       |
+| `secrets`    | List of objects of [secrets](#secrets) | list(object) | `null`      | yes      |
+| `tags`       | Key-value map of tags                  | map(string)  | `{}`        | no       |
 
 ### Secrets
 
 | Name           | Description                                           | Type   | Default |
-| -------------- | ----------------------------------------------------- | ------ | ------- |
+|:---------------|:------------------------------------------------------|:-------|:--------|
 | `name`         | Secret name                                           | string | `null`  |
 | `value`        | Secret value                                          | string | `null`  |
 | `allowed_arns` | List of principal ARNs that have access to the secret | list   | `null`  |
@@ -228,7 +228,7 @@ module "user" {
 ## Outputs
 
 | Name            | Description                              | Sensitive |
-| --------------- | ---------------------------------------- | --------- |
+|:----------------|:-----------------------------------------|:----------|
 | `all`           | Map of names and arns of created secrets | yes       |
 | `kms_key_arn`   | The master key ARN                       | no        |
 | `kms_alias_arn` | The master key alias ARN                 | no        |

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.7"
+  required_version = ">= 1.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
## Description

The PR drops Terraform (TF) support lower than 1.0, namely:
* Bumps the min TF version to v1.0.0
* It updates the deployment pipeline to stop checking the configuration against TF 0.13.x, 0.14.x

Note: A new major version will be released as the PR contains breaking change.

## Testing considerations

The pipelines are green.

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [x] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-3091](https://scribdjira.atlassian.net/browse/SERF-3091)
* [Module usage](https://github.com/search?q=org%3Ascribd+terraform-aws-app-secrets++NOT+is%3Aarchived&type=code&p=1)

[commit messages]: https://chris.beams.io/posts/git-commit/


[SERF-3091]: https://scribdjira.atlassian.net/browse/SERF-3091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ