### PR TITLE
Add delete_in argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A module to create application secrets stored in [AWS Secrets Manager](https://a
   * [Cross-account secrets](#cross-account-secrets)
 * [Inputs](#inputs)
   * [Secrets](#secrets)
+  * [Recovery window](#recovery-window)
 * [Outputs](#outputs)
 * [Release](#release)
 * [Maintainers](#maintainers)
@@ -210,12 +211,13 @@ module "user" {
 
 ## Inputs
 
-| Name         | Description                            | Type         | Default     | Required |
-|:-------------|:---------------------------------------|:-------------|:------------|:---------|
-| `app_name`   | Application name                       | string       | `null`      | yes      |
-| `aws_region` | AWS region                             | string       | `us-east-2` | no       |
-| `secrets`    | List of objects of [secrets](#secrets) | list(object) | `null`      | yes      |
-| `tags`       | Key-value map of tags                  | map(string)  | `{}`        | no       |
+| Name         | Description                                                       | Type         | Default     | Required |
+|:-------------|:------------------------------------------------------------------|:-------------|:------------|:---------|
+| `app_name`   | Application name                                                  | string       | `null`      | yes      |
+| `aws_region` | AWS region                                                        | string       | `us-east-2` | no       |
+| `secrets`    | List of objects of [secrets](#secrets)                            | list(object) | `null`      | yes      |
+| `delete_in`  | [Number of days](#recovery-window) to wait before secret deletion | number       | `30`        | no       |
+| `tags`       | Key-value map of tags                                             | map(string)  | `{}`        | no       |
 
 ### Secrets
 
@@ -224,6 +226,10 @@ module "user" {
 | `name`         | Secret name                                           | string | `null`  |
 | `value`        | Secret value                                          | string | `null`  |
 | `allowed_arns` | List of principal ARNs that have access to the secret | list   | `null`  |
+
+### Recovery window
+
+Number of days that AWS Secrets Manager waits before it can delete the secret. This value can be `0` to force deletion without recovery or range from `7` to `30` days. The default value is `30`.
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -24,6 +24,8 @@ resource "aws_secretsmanager_secret" "app" {
 
   policy = lookup(local.arns, each.key, null) == null ? null : data.aws_iam_policy_document.access[each.key].json
 
+  recovery_window_in_days = var.delete_in
+
   tags = merge(var.tags, { "service" = var.app_name })
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,18 @@ variable "secrets" {
   )
 }
 
+variable "delete_in" {
+  description = "Number of days to wait before secret deletion"
+  type        = number
+
+  default = 30
+
+  validation {
+    condition     = var.delete_in == 0 || contains(range(7, 30), var.delete_in)
+    error_message = "The delete_in value must be 0 or between 7 and 30."
+  }
+}
+
 variable "tags" {
   description = "Key-value map of tags"
   type        = map(string)


### PR DESCRIPTION
## Description

By default Secrets Manager uses a 30 day recovery window to wait before permanently deleting the secret. In many cases, there is no need to wait for 30 days to delete a secret.

The PR exposes the `delete_in` argument to configure the recovery window. The number of days must be between `7` and `30`. If the value is set to `0` it will trigger force deletion without recovery.

## Testing considerations

The change was tested in one of our root modules.

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [ ] ~Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->~
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [x] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [AWS Secrets Manager secret deletion](https://docs.aws.amazon.com/secretsmanager/latest/userguide/manage_delete-secret.html)
* [Terraform secretsmanager_secret](https://registry.terraform.io/providers/hashicorp/aws/4.67.0/docs/resources/secretsmanager_secret)

[commit messages]: https://chris.beams.io/posts/git-commit/
