### PR TITLE
Include 30 to the day range of the recovery window

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -28,7 +28,7 @@ variable "delete_in" {
   default = 30
 
   validation {
-    condition     = var.delete_in == 0 || contains(range(7, 30), var.delete_in)
+    condition     = var.delete_in == 0 || contains(range(7, 31), var.delete_in)
     error_message = "The delete_in value must be 0 or between 7 and 30."
   }
 }


### PR DESCRIPTION
## Description

A follow-up PR to https://github.com/scribd/terraform-aws-app-secrets/pull/21 to fix the validation failure when the `delete_in` value is set to the default value:

```hcl
│ Error: Invalid value for variable
│ 
│   on .terraform/modules/app_go_chassis.secrets/variables.tf line 24:
│   24: variable "delete_in" {
│ 
│ The delete_in value must be 0 or between 7 and 30.
```

## Testing considerations

The fix is tested in on of our root modules

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [ ] ~Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->~
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] ~Updated the `README.md` as necessary~

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* https://github.com/scribd/terraform-aws-app-secrets/pull/21

[commit messages]: https://chris.beams.io/posts/git-commit/
