### PR TITLE
[TOOLS-7104] Update github actions due to node 16 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         activity: ["1.0.11", "1.1.9", "1.2.9", "1.3.10", "1.4.7", "1.5.7"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup terraform ${{ matrix.activity }}
         uses: hashicorp/setup-terraform@v3
@@ -34,7 +34,7 @@ jobs:
   codeowners:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: GitHub CODEOWNERS Validator
         uses: mszostok/codeowners-validator@v0.7.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Use sourcegraph batch change to update github actions due to node 16 deprecation.

[_Created by Sourcegraph batch change `kristianmills/sourcegraph-node-16-v2`._](https://scribd.sourcegraphcloud.com/users/kristianmills/batch-changes/sourcegraph-node-16-v2)