### PR TITLE
Bump scribd/terraform-service-foundations to v1.5.0

### DIFF
--- a/.cursor/rules/git-commits.mdc
+++ b/.cursor/rules/git-commits.mdc
@@ -1,0 +1,248 @@
+---
+description: Git commit guidelines to ensure consistent and error-free commits
+globs:
+---
+
+# Git Commit Guidelines
+
+## Commit Message Format
+
+### Structure
+
+The commit message should be structured as follows:
+  ```
+  <type>[optional scope]: <description>
+
+  [optional body]
+
+  [optional footer(s)]
+  ```
+
+### Types
+
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation
+- `style`: Formatting
+- `refactor`: Code restructuring
+- `test`: Test changes
+- `chore`: Maintenance
+
+## Specification
+
+- Commits MUST be prefixed with a type, which consists of a noun, feat, fix, etc., followed by the OPTIONAL scope, OPTIONAL !, and REQUIRED terminal colon and space.
+- The type feat MUST be used when a commit adds a new feature to your application or library.
+- The type fix MUST be used when a commit represents a bug fix for your application.
+- A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):
+- A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.
+- A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
+- A commit body is free-form and MAY consist of any number of newline separated paragraphs.
+- One or more footers MAY be provided one blank line after the body. Each footer MUST consist of a word token, followed by either a :<space> or <space># separator, followed by a string value (this is inspired by the git trailer convention).
+- A footer’s token MUST use - in place of whitespace characters, e.g., Acked-by (this helps differentiate the footer section from a multi-paragraph body). An exception is made for BREAKING CHANGE, which MAY also be used as a token.
+- A footer’s value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer token/separator pair is observed.
+- Breaking changes MUST be indicated in the type/scope prefix of a commit, or as an entry in the footer.
+- If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g., BREAKING CHANGE: environment variables now take precedence over config files.
+- If included in the type/scope prefix, breaking changes MUST be indicated by a ! immediately before the :. If ! is used, BREAKING CHANGE: MAY be omitted from the footer section, and the commit description SHALL be used to describe the breaking change.
+- Types other than feat and fix MAY be used in your commit messages, e.g., docs: update ref docs.
+- The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
+
+## Error Prevention
+
+### ✅ CORRECT Patterns
+
+- Commit message with description and breaking change footer:
+  ```bash
+  git commit -m 'feat: allow provided config object to extend other configs' -m 'BREAKING CHANGE: `extends` key in config file is now used for extending other config files'
+  ```
+
+- Commit message with ! to draw attention to breaking change:
+  ```bash
+  git commit -m "feat!: send an email to the customer when a product is shipped"
+  ```
+
+- Commit message with scope and ! to draw attention to breaking change
+  ```bash
+  git commit -m "feat(api)!: send an email to the customer when a product is shipped"
+  ```
+
+- Commit message with both ! and BREAKING CHANGE footer:
+  ```bash
+  git commit -m "chore!: drop support for Node 6" -m "BREAKING CHANGE: use JavaScript features not available in Node 6."
+  ```
+
+- Commit message with no body:
+  ```bash
+  git commit -m "docs: correct spelling of CHANGELOG"
+  ```
+
+- Commit message with scope:
+  ```bash
+  git commit -m "feat(lang): add Polish language"
+  ```
+
+- Commit message with multi-paragraph body and multiple footers:
+  ```bash
+  git commit -m "fix: prevent racing of requests
+
+  Introduce a request id and a reference to latest request. Dismiss
+  incoming responses other than from latest request.
+
+  Remove timeouts which were used to mitigate the racing issue but are
+  obsolete now.
+
+  Reviewed-by: Z
+  Refs: #123"
+  ```
+
+### ❌ INCORRECT Patterns
+
+  ```bash
+  # No prefix used
+  git commit -m "Add code"
+  ```
+
+## Best Practices
+
+### Message Guidelines
+
+1. Use one of the message types from the list of the provided above types
+2. Use imperative mood ("add" not "adds")
+3. Keep first line under 50 characters
+4. No period at end of subject line
+5. Be specific and clear
+6. Reference issue numbers when relevant
+
+### Commit Organization
+
+1. Make atomic commits (one logical change)
+2. Verify changes before committing
+3. Run tests before pushing
+4. Review the diff before committing
+5. Keep commits focused and small
+
+## Common Patterns
+
+### Feature Work
+
+  ```bash
+  git commit -m "feat(user): add email verification"
+  git commit -m "feat(auth): implement 2FA support"
+  ```
+
+### Bug Fixes
+
+  ```bash
+  git commit -m "fix(api): resolve rate limiting issue"
+  git commit -m "fix(ui): correct button alignment"
+  ```
+
+### Documentation
+
+  ```bash
+  git commit -m "docs(api): update endpoint documentation"
+  git commit -m "docs(setup): add deployment guide"
+  ```
+
+### Refactoring
+
+  ```bash
+  git commit -m "refactor(core): optimize data processing"
+  git commit -m "refactor(auth): simplify login flow"
+  ```
+
+## Recovery Procedures
+
+### Fix Last Commit
+
+  ```bash
+  # Amend commit message
+  git commit --amend -m "type(scope): corrected message"
+
+  # Amend commit content
+  git add forgotten-file
+  git commit --amend --no-edit
+  ```
+
+### Split Failed Commit
+
+  ```bash
+  # Reset last commit
+  git reset HEAD~1
+
+  # Commit changes separately
+  git add feature-files
+  git commit -m "feat(scope): first part"
+  git add test-files
+  git commit -m "test(scope): add tests"
+  ```
+
+## Pre-commit Checklist
+
+### Code Quality
+
+- Run linters
+- Check formatting
+- Remove debug code
+- Run tests
+
+### Security
+
+- No sensitive data
+- No API keys
+- No credentials
+- Check file permissions
+
+### Commit Message
+
+- Correct type and scope
+- Clear description
+- Reference issues if applicable
+
+### Changes
+
+- Review diff
+- Verify file inclusions
+- Check for unintended changes
+- Confirm test coverage
+
+### Mandatory Diff Review
+
+#### Pre-Commit Diff Check
+
+Before any commit, ALWAYS run:
+
+  ```bash
+  # Check status first
+  git status | cat
+
+  # Then review changes in detail
+  git diff | cat
+
+  # For staged changes
+  git diff --staged | cat
+  ```
+
+#### Diff Review Checklist
+
+1. File Changes
+  - Confirm all intended files are modified
+  - No unintended file deletions
+  - No sensitive files exposed
+
+2. Code Changes
+  - Review each chunk of changes
+  - Verify line deletions are intentional
+  - Check for debugging code
+  - Confirm formatting changes
+
+3. Large Changes Warning
+  - If more than 500 lines changed, break into smaller commits
+  - For large deletions, double-check necessity
+  - Request confirmation for significant file removals
+
+4. Post-Review Actions
+  - Address any unintended changes
+  - Remove debug statements
+  - Fix formatting issues
+  - Split into multiple commits if needed

--- a/.cursor/rules/terraform-additional-rules.mdc
+++ b/.cursor/rules/terraform-additional-rules.mdc
@@ -1,0 +1,102 @@
+---
+description: Additional Terraform guidelines for best practices, security, and maintainability.
+globs: *.tf
+alwaysApply: false
+---
+
+# Terraform common guidelines
+
+- **Use Remote State**: Store Terraform state files remotely to enable collaboration and prevent conflicts. Use AWS S3 with DynamoDB locking.
+    - Properly configure access controls for your remote state backend to prevent unauthorized access.
+    - Implement versioning for state files to track changes and facilitate rollbacks.
+- **Validation and Formatting**: Always validate and format Terraform code using `terraform fmt` and `terraform validate` to ensure quality and consistency.
+    - Integrate `terraform fmt` and `terraform validate` into your CI/CD pipeline.
+    - Use a linter such as TFLint to enforce organization-specific coding best practices.
+- **Use Existing Shared and Community Modules**: Leverage pre-built modules from the Terraform Registry or other trusted sources to avoid reinventing the wheel.
+    - Thoroughly review modules before use to understand their functionality and security implications.
+    - Pin module versions to prevent unexpected changes.
+- **Import Existing Infrastructure**: Use the `terraform import` command to bring existing infrastructure under Terraform management.
+    - Understand the limitations of `terraform import` and manually verify the imported configuration.
+- **Tag Resources**: Tag all Terraform resources with relevant metadata (`department`, `env`, `repo`, `terraform`).
+    - Use consistent tagging conventions across your infrastructure.
+    - Leverage tags for cost allocation and resource management.
+- **Common Patterns and Anti-patterns:**
+    - **Design Patterns:**
+        - **Singleton Pattern:** Ensure only one instance of a critical resource exists (e.g., a VPC). Use `count = var.create_vpc ? 1 : 0` to conditionally create a single VPC.
+        - **Factory Pattern:** Use modules to create multiple instances of a resource with different configurations (e.g., multiple EC2 instances with different sizes and roles).
+        - **Facade Pattern:** Create a module that simplifies the creation of complex infrastructure by abstracting away the underlying details.
+    - **Recommended Approaches:**
+        - Use data sources to retrieve information about existing resources instead of hardcoding their IDs or names.
+        - Use dynamic blocks to create multiple resources or configure resource properties based on variable values.
+        - Use lifecycle rules to manage resource creation, modification, and deletion.
+    - **Anti-patterns:**
+        - **Hardcoding values:** Avoid hardcoding values in your Terraform configurations. Use variables instead.
+        - **Creating monolithic configurations:** Break down large configurations into smaller, more manageable modules.
+        - **Ignoring errors:** Always handle errors and provide meaningful error messages.
+    - **State Management Best Practices:**
+        - **Remote State:** Always use remote state to store Terraform state files.
+        - **State Locking:** Enable state locking to prevent concurrent modifications.
+        - **State Encryption:** Encrypt state files to protect sensitive data.
+        - **State Versioning:** Implement versioning for state files.
+    - **Error Handling Patterns:**
+        - Use the `try` and `can` functions to handle errors when retrieving data or evaluating expressions.
+        - Use `validation` blocks to validate variable values and prevent invalid configurations.
+        - Provide meaningful error messages to help users diagnose and fix issues.
+- **Performance Considerations:**
+    - **Optimization Techniques:**
+        - Use the `count` and `for_each` meta-arguments to create multiple resources efficiently.
+        - Use data sources to retrieve information about existing resources instead of creating new ones.
+        - Use the `depends_on` meta-argument sparingly to avoid unnecessary dependencies.
+    - **Memory Management:**
+        - Be mindful of the memory usage of your Terraform configurations, especially when working with large datasets.
+        - Avoid creating large variables or outputs that can consume excessive memory.
+    - **Rendering Optimization:**
+        - Use efficient string interpolation techniques to avoid unnecessary string concatenation.
+        - Use the `templatefile` function to render complex templates efficiently.
+- **Security Best Practices:**
+    - **Common Vulnerabilities:**
+        - **Hardcoded secrets:** Avoid hardcoding secrets in your Terraform configurations.
+        - **Publicly accessible resources:** Ensure that resources are not publicly accessible unless explicitly required.
+        - **Insufficient access controls:** Implement strict access controls to prevent unauthorized access to resources.
+    - **Input Validation:**
+        - Validate variable values to prevent invalid or malicious input.
+        - Use regular expressions to enforce specific input formats.
+    - **Authentication and Authorization Patterns:**
+        - Use IAM roles and policies to grant resources the necessary permissions.
+        - Use Terraform Cloud or other secrets management tools to manage sensitive credentials.
+    - **Data Protection Strategies:**
+        - Encrypt sensitive data at rest and in transit.
+        - Use encryption keys managed by a key management service (KMS).
+    - **Secure API Communication:**
+        - Use HTTPS for all API communication.
+        - Validate API responses to prevent data injection attacks.
+- **Testing Approaches:**
+    - **Unit Testing Strategies:**
+        - Use `terraform show` and `terraform plan` to verify that your Terraform configurations create the expected resources.
+        - Use `terratest` or other testing frameworks to write automated unit tests.
+- **Common Pitfalls and Gotchas:**
+    - **Frequent Mistakes:**
+        - **Incorrect resource dependencies:** Ensure that resource dependencies are correctly defined.
+        - **Ignoring resource lifecycle:** Understand the lifecycle of Terraform resources and how they are created, modified, and deleted.
+        - **Using outdated Terraform versions:** Keep your Terraform version up to date to take advantage of new features and bug fixes.
+    - **Edge Cases:**
+        - **Handling resource conflicts:** Be prepared to handle resource conflicts that can occur when multiple Terraform configurations are applied simultaneously.
+        - **Managing resources with external dependencies:** Be aware of resources that have external dependencies (e.g., DNS records) and handle them appropriately.
+    - **Version-specific Issues:**
+        - Be aware of version-specific issues and compatibility concerns when upgrading Terraform or provider versions.
+        - Consult the Terraform and provider documentation for any breaking changes or migration guides.
+    - **Compatibility Concerns:**
+        - Ensure that your Terraform configurations are compatible with the target infrastructure environment.
+        - Use provider versions that are compatible with the Terraform version.
+- **Tooling and Environment:**
+    - **Recommended Development Tools:**
+        - **Terraform CLI:** The official Terraform command-line interface.
+        - **IDE/Text Editor:** Cursor editor (recommended) for seamless integration with project guidelines.
+        - **TFLint:** A linter for Terraform code.
+        - **Terratest:** A testing framework for Terraform code.
+    - **Build Configuration:**
+        - Use a consistent build configuration across all environments.
+        - Use environment variables to configure the build environment.
+    - **Linting and Formatting:**
+        - Integrate linting and formatting into your CI/CD pipeline.
+        - Use `terraform fmt` and TFLint to ensure code quality and consistency.

--- a/.cursor/rules/terraform-input-variables.mdc
+++ b/.cursor/rules/terraform-input-variables.mdc
@@ -1,0 +1,116 @@
+---
+description: Terraform input variables
+globs: *.tf
+alwaysApply: false
+---
+
+# Terraform module input variables
+
+- Declare all input variables in variables.tf.
+- Don’t use any shortcuts for the filename, such as var.tf, vars.tf.
+- Give variables descriptive names that are relevant to their usage or purpose:
+  - To simplify conditional logic, give boolean variables positive names - for example, external_access_enabled.
+- Variables must have descriptions. Try to keep the description short. Document possible caveats and edge cases separately in the README.md file of the module:
+
+  ```hcl
+  # ✅ Good example
+
+  variable "ecs_memory" {
+    description = "Memory units for the ECS task"
+    type        = string
+  }
+  ```
+
+  ```hcl
+  # ❌ Bad Example
+
+  variable "ecs_memory" {
+    description = "Memory Units for the ECS task (8192 = 8GB, 8192 is the minimum for 4 vCPU). In general this should be: max memory for the instance / (expected # ECS tasks * memory per task) - reserved system memory.  This way, EC2 instance will have enough reserved memory to do a rolling restart for the required number of tasks."
+    type        = string
+  }
+  ```
+
+- The description of a variable must always begin with a capital letter:
+
+  ```hcl
+  # ✅ Good example
+
+  variable "ecs_memory" {
+    description = "Memory units for the ECS task"
+    type        = string
+  }
+  ```
+
+  ```hcl
+  # ❌ Bad Example
+
+  variable "ecs_memory" {
+    description = "memory units for the ECS task"
+    type        = string
+  }
+  ```
+
+- Document variable descriptions in the README.md file.
+- Give variables defined types:
+
+  ```hcl
+  # ✅ Good example
+
+  variable "ecs_memory" {
+    description = "Memory units for the ECS task"
+    type        = string
+  }
+  ```
+
+  ```hcl
+  # ❌ Bad Example
+
+  variable "ecs_memory" {
+    description = "Memory units for the ECS task"
+  }
+  ```
+
+- When appropriate, provide default values:
+  - For variables that have environment-independent values (such as disk size), provide default values.
+  - For variables that have environment-specific values (such as project_id), don't provide default values. This way, the calling module must provide meaningful values.
+- Use empty defaults for variables (like empty strings or lists) only when leaving the variable empty is a valid preference that the underlying APIs don't reject.
+- When appropriate, make sure that the values are marked as sensitive to prevent Terraform from showing its value in the plan or apply output.
+- Organize the variable arguments in the following order: description, type, sensitive, default, and validation. The validation argument must be split by an empty line from other ones. It ensures the variable naming is consistent. It also increases the readability of the code:
+
+  ```hcl
+  # ✅ Good example
+
+  variable "ecs_memory" {
+    description = "Memory units for the ECS task"
+    type        = string
+    sensitive   = false
+    default     = "8GB"
+
+    validation {
+      condition     = contains(["1GB", "2GB", "4GB", "8GB"], var.ecs_memory)
+      error_message = "The ecs_memory must be either 1GB, 2GB, 4GB, or 8GB."
+    }
+  }
+  ```
+
+  ```hcl
+  # ❌ Bad Example
+
+  variable "ecs_memory" {
+    default = "8GB"
+    description = "Memory units for the ECS task"
+    type = string
+    sensitive = false
+    validation {
+      condition     = contains(["1GB", "2GB", "4GB", "8GB"], var.ecs_memory)
+      error_message = "The ecs_memory must be either 1GB, 2GB, 4GB, or 8GB."
+    }
+  }
+  ```
+
+- Be judicious in your use of variables. Only parameterize values that must vary for each instance or environment. When deciding whether to expose a variable, ensure that you have a concrete use case for changing that variable. If there's only a small chance that a variable might be needed, don't expose it.
+  - Adding a variable with a default value is backward-compatible.
+  - Removing a variable is backward-incompatible.
+  - In cases where a literal is reused in multiple places, you can use a local value without exposing it as a variable.
+- If you have a variable to enable/disable the module, it must be called enabled and has to be defined as the very first variable on the list of input variables.
+- If you have a variable to assign tags to your resources, it must be called tags and has to be defined as the very last variable on the list of input variables.

--- a/.cursor/rules/terraform-module-structure.mdc
+++ b/.cursor/rules/terraform-module-structure.mdc
@@ -1,0 +1,71 @@
+---
+description: General Terraform style and structure
+globs: *.tf
+alwaysApply: false
+---
+
+# Standard Terraform module structure
+
+- Terraform modules must follow the standard module structure:
+
+    ├── charts/
+    ├── config/
+    │   ├── development/
+    │   │   ├── backend.tf # Development environment backend config
+    │   │   └── terraform.tfvars # Environment-specific values
+    │   ├── staging/
+    │   │   ├── backend.tf # Staging environment backend config
+    │   │   └── terraform.tfvars # Environment-specific values
+    │   ├── production/
+    │   │   ├── backend.tf # Production environment backend config
+    │   │   └── terraform.tfvars # Environment-specific values
+    ├── docs/
+    ├── files/
+    ├── modules/
+    ├── scripts/
+    ├── templates/
+    ├── locals.tf # Module local variables
+    ├── main.tf # Top-level resources (if any)
+    ├── variables.tf # Global variables
+    ├── versions.tf # Terraform and provider versions
+    └── outputs.tf # Global outputs
+
+- Usually, the standard module structure looks like this:
+  - locals.tf - contains local variables used in the module
+  - main.tf - call modules and data sources to create all resources
+  - outputs.tf - returns results to the calling module
+  - variables.tf - contains declarations of module variables used in main.tf
+  - versions.tf - contains version requirements for Terraform and providers
+- Start every module with a main.tf file, where resources are located by default.
+- In every module, include a README.md file in Markdown format. In the README.md file, include basic documentation about the module.
+- Place examples in an examples/ folder, with a separate subdirectory for each example. For each example, include a detailed README.md file.
+- Create logical groupings of resources with their files and descriptive names, such as networks.tf, instances.tf, or loadbalancers.tf. Prefer a plural form of nouns for the filenames.
+- Avoid giving every resource its own file. Group resources by their shared purpose.
+- Name files using dashes to delimit multiple words (no underscores).
+- In the module's root directory, include only Terraform (*.tf) and repository metadata files (such as README.md and CHANGELOG.md).
+- Place any additional documentation in a docs/ subdirectory if necessary.
+
+## Data sources
+
+- Put data sources next to the resources that reference them. For example, if you are fetching an image to be used in launching an instance, place it alongside the instance instead of collecting data resources in a separate file.
+- Only when the number of data sources becomes large, consider moving them to dedicated data.tf file.
+- To fetch data relative to the current environment, use variable or resource interpolation.
+
+## Custom scripts
+
+- Use scripts only when necessary. The state of resources created through scripts is not accounted for or managed by Terraform.
+- Avoid custom scripts, if possible. Use them only when Terraform resources don't support the desired behavior.
+- Any custom scripts used must have a documented reason for existing and ideally a deprecation plan.
+- Put custom scripts called by Terraform in a scripts/ directory.
+
+## Static files and templates
+
+- Static files that Terraform references but doesn't execute (such as startup scripts loaded onto EC2 instances) must be organized into a files/ directory.
+- Place lengthy HereDocs in external files, separate from their HCL. Reference them with the file() function.
+- For files that are read in by using the Terraform templatefile function, use the file extension .tmpl.
+- Templates must be placed in a templates/ directory.
+
+## Helm charts
+
+- Helm charts must follow the standard chart structure.
+- Put custom Helm charts called by Terraform in a charts/ directory.

--- a/.cursor/rules/terraform-naming-convention.mdc
+++ b/.cursor/rules/terraform-naming-convention.mdc
@@ -1,0 +1,122 @@
+---
+description: Terraform module naming convention
+globs: *.tf
+alwaysApply: false
+---
+
+# Terraform naming convention
+
+- Name all configuration objects using underscores to delimit multiple words (no dashes). This practice ensures consistency with the naming convention for resource types, data source types, and other predefined values. This convention does not apply to name arguments.
+
+  ```hcl
+  # ✅ Good example
+
+  resource "aws_acm_certificate" "internal_gateway" {
+    domain_name = "mesh.scribd.com"
+    ...
+  }
+  ```
+
+  ```hcl
+  # ❌ Bad Example
+
+  resource "aws_acm_certificate" "internal-gateway" {
+    domain_name = "mesh.scribd.com"
+    ...
+  }
+  ```
+
+- To differentiate resources of the same type from each other (for example, primary and secondary), provide meaningful resource names.
+- Make resource names singular.
+- In the resource name, don't repeat the resource type. For example:
+
+  ```hcl
+  # ✅ Good example
+
+  resource "aws_secretsmanager_secret" "datadog_api_key" { ... }
+  ```
+
+  ```hcl
+  # ❌ Bad Example
+
+  resource "aws_secretsmanager_secret" "datadog_api_key_secretsmanager_secret" { … }
+  ```
+
+- Place the argument count or for_each, if required, as the very first argument. The argument should be separated by a single empty line:
+
+  ```hcl
+  # ✅ Good examples
+
+  resource "aws_s3_bucket" "assets" {
+    count = 2
+
+    bucket = "scribd-assets-${var.environment}-${count.index}"
+  }
+
+  resource "aws_s3_bucket" "static_files" {
+    for_each = local.static_buckets
+
+    bucket = each.key
+  }
+  ```
+
+  ```hcl
+  # ❌ Bad Examples
+
+  resource "aws_s3_bucket" "assets" {
+    count  = 2
+    bucket = "scribd-assets-${var.environment}-${count.index}"
+  }
+
+  resource "aws_s3_bucket" "javascripts" {
+    bucket = "scribd-javascripts-${var.environment}-${count.index}"
+    count  = 2
+  }
+
+  resource "aws_s3_bucket" "static_files" {
+    for_each = local.static_buckets
+    bucket   = each.key
+  }
+  ```
+
+- Place the argument tags, if supported by resource, as the last real argument, followed by depends_on and lifecycle, if necessary. All of these should be separated by a single empty line:
+
+  ```hcl
+  # ✅ Good example
+
+  resource "aws_s3_bucket" "assets" {
+    bucket = "scribd-assets-${var.environment}"
+
+    tags = {
+      department  = "service-foundations"
+      environment = var.environment
+    }
+
+    depends_on = [aws_internet_gateway.main]
+
+    lifecycle {
+      create_before_destroy = true
+    }
+  }
+  ```
+
+  ```hcl
+  # ❌ Bad Example
+
+  resource "aws_s3_bucket" "assets" {
+    bucket = "scribd-assets-${var.environment}"
+
+    tags = {
+      department  = "service-foundations"
+      environment = var.environment
+    }
+
+    force_destroy = true
+
+    depends_on = [aws_internet_gateway.main]
+
+    lifecycle {
+      create_before_destroy = true
+    }
+  }
+  ```

--- a/.cursor/rules/terraform-outputs.mdc
+++ b/.cursor/rules/terraform-outputs.mdc
@@ -1,0 +1,82 @@
+---
+description: Terraform output rules
+globs: *.tf
+alwaysApply: false
+---
+
+# Terraform module outputs
+
+- Organize all outputs in an outputs.tf file.
+- Don’t use any shortcuts for the filename, such as out.tf, outs.tf.
+- Provide meaningful descriptions for all outputs:
+
+  ```hcl
+  # ✅ Good example
+
+  output "ecr_repository_name" {
+    description = "ECR Repository name"
+    value       = module.ecr.ecr_repository_name
+  }
+  ```
+
+  ```hcl
+  # ❌ Bad Example
+
+  output "ecr_repository_name" {
+    value = var.ecr_repository_name
+  }
+  ```
+
+- The description of an output must always begin with a capital letter:
+
+  ```hcl
+  # ✅ Good example
+
+  output "ecr_repository_name" {
+    description = "ECR Repository name"
+    value       = module.ecr.ecr_repository_name
+  }
+  ```
+
+  ```hcl
+  # ❌ Bad Example
+
+  output "ecr_repository_name" {
+    description = "ecr repository name"
+    value       = module.ecr.ecr_repository_name
+  }
+  ```
+
+- Document output descriptions in the README.md file.
+- Output all useful values that root modules might need to refer to or share. Especially for heavily used modules, expose all outputs that have the potential for consumption.
+- Don't pass outputs directly through input variables if possible, because doing so prevents them from being properly added to the dependency graph. To ensure that implicit dependencies are created, make sure that outputs reference attributes from resources. Instead of referencing an input variable for an instance directly, pass the attribute through as shown here:
+
+  ```hcl
+  # ✅ Good example
+
+  output "ecr_repository_name" {
+    description = "ECR Repository name"
+    value       = module.ecr.ecr_repository_name
+  }
+  ```
+
+  ```hcl
+  # ❌ Bad Example
+
+  output "ecr_repository_name" {
+    description = "ECR Repository name"
+    value       = var.ecr_repository_name
+  }
+  ```
+
+- When exporting sensitive values to output, make sure that the values are marked as sensitive:
+
+  ```hcl
+  # ✅ Good example
+
+  output "ecr_repository_name" {
+    description = "ECR Repository name"
+    value       = module.ecr.ecr_repository_name
+    sensitive   = true
+  }
+  ```

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,4 @@
+.terraform/
+.debug/
+
+terraform.tfstate*


### PR DESCRIPTION
The PR applies changes from scribd/terraform-service-foundations between versions v0.0.0 and v1.5.0:
* :white_check_mark: [ [PATCH 647/690] feat: add preliminary Cursor rules](https://github.com/scribd/terraform-service-foundations/commit/4e1878d4d5fec2cace346d433a8ecbcc1ee9502c)
* :white_check_mark: [ [PATCH 648/690] feat: add .cursorignore](https://github.com/scribd/terraform-service-foundations/commit/7267864a32ad6d010a4aa4f017bae8791eb40b99)

_This is an auto-generated pull request created by the [Parity workflow](https://github.com/scribd/terraform-service-foundations/actions/runs/17583344849/workflow), and can be updated with the newest changes by re-running [the same job](https://github.com/scribd/terraform-service-foundations/actions/runs/17583344849)._

_For more information contact the @scribd/tools team._