### PR TITLE
chore: Rename @scribd/service-foundations to @scribd/developer-tooling in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,12 +4,12 @@
 # requests.
 #
 # Rules should follow the standard of a file matching pattern followed by a
-# team name, e.g. @scribd/service-foundations. Do not use broad teams, such as
+# team name, e.g. @scribd/developer-tooling. Do not use broad teams, such as
 # "Engineering", for code ownership.
 #
 # All lines starting with a `#` are comments and will be ignored.
 #
 # Order is important. The last matching pattern wins.
 
-# Service Foundations parent ownership
-*    @scribd/service-foundations
+# Developer Tooling parent ownership
+*    @scribd/developer-tooling


### PR DESCRIPTION
Rename `@scribd/service-foundations` to `@scribd/developer-tooling` in CODEOWNERS.

[DEVPLAT-7095](https://scribdjira.atlassian.net/browse/DEVPLAT-7095)

[DEVPLAT-7095]: https://scribdjira.atlassian.net/browse/DEVPLAT-7095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only changes CODEOWNERS reviewer assignment and does not affect runtime code or behavior.
> 
> **Overview**
> Updates `CODEOWNERS` to replace the default `*` owner from `@scribd/service-foundations` to `@scribd/developer-tooling`, reflecting the team rename and changing who is auto-requested for reviews.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 028ab81b140e4b7b5267eb3972aaf872ee00de64. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->