### PR TITLE
chore: DEVPLAT-7373 fix Node.js 20 deprecated GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         activity: ["1.0.11", "1.1.9", "1.2.9", "1.3.10", "1.4.7", "1.5.7"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup terraform ${{ matrix.activity }}
         uses: hashicorp/setup-terraform@v3
@@ -34,7 +34,7 @@ jobs:
   codeowners:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: GitHub CODEOWNERS Validator
         uses: mszostok/codeowners-validator@v0.7.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions that use the deprecated Node.js 20 runtime to Node.js 24 compatible versions.

Node.js 20 actions will be forced to run on Node.js 24 by default starting **June 2nd, 2026**. See the [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

**Changes made:**
- `actions/checkout@v4` → `actions/checkout@v6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVPLAT-7373](https://scribd.atlassian.net/browse/DEVPLAT-7373)


[DEVPLAT-7373]: https://scribdjira.atlassian.net/browse/DEVPLAT-7373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk workflow maintenance change that only upgrades `actions/checkout` used by CI and release jobs. Potential impact is limited to GitHub Actions checkout behavior/version compatibility.
> 
> **Overview**
> Updates the `CI` and `Release` GitHub Actions workflows to use **`actions/checkout@v6`** (from `v4`) for the Terraform validate/codeowners jobs and the semantic-release workflow, addressing upcoming Node runtime deprecations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45ddfe7c2e115c02a71709b61b9ad1d752a4b61e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->